### PR TITLE
Remove zero case for trial function

### DIFF
--- a/repeater.go
+++ b/repeater.go
@@ -30,7 +30,7 @@ var waitTimes []time.Duration = []time.Duration{
 // invoke PowerShell.exe and run
 func newRepeater(ctx context.Context) (*repeater, error) {
 	for i, limit := range waitTimes {
-		log.Printf("invoking [W] in PowerShell.exe%s", trial(i+1))
+		log.Printf("invoking [W] in PowerShell.exe%s", trial(i))
 
 		cmd := exec.Command("PowerShell.exe", "-Command", "-")
 		in, err := cmd.StdinPipe()


### PR DESCRIPTION
The only two usages of the `trial` function come from `range` loop (starting at 0 on the `waitTimes` slice). Since we have `(i+1)` in the the `Sprintf` args, there is now no possibility to get into the `i == 0` `if` branch.

This also leaves both usages with `trial(i)`.