### PR TITLE
disconnect named pipe after read

### DIFF
--- a/repeater.ps1
+++ b/repeater.ps1
@@ -35,16 +35,17 @@ Function MainLoop {
 		$buf[0] = 0xff
 		$ssh_client_out.Write($buf, 0, 1)
 	
-		while($true) {
-			Try{
+		while ($true) {
+			Try {
 				$null = $ssh_client_in.Read((New-Object byte[] 1), 0, 0)
 				$ssh_agent = New-Object System.IO.Pipes.NamedPipeClientStream ".", "openssh-ssh-agent", InOut
 				$ssh_agent.Connect()
 				Log "[W] named pipe: connected"
 				$len = RelayMessage $ssh_client_in $ssh_agent $buf "->"
 				$len = RelayMessage $ssh_agent $ssh_client_out $buf "<-"
-			}Finally{
-				If($null -ne $ssh_agent){
+			}
+			Finally {
+				if ($null -ne $ssh_agent) {
 					$ssh_agent.Dispose()
 					Log "[W] named pipe: disconnected"
 				}

--- a/repeater.ps1
+++ b/repeater.ps1
@@ -24,10 +24,7 @@ Function RelayMessage($from, $to, $buf, $arrow) {
 }
 
 Function MainLoop {
-	Try {
-		$ssh_agent = New-Object System.IO.Pipes.NamedPipeClientStream ".", "openssh-ssh-agent", InOut
-		$ssh_agent.Connect()
-		
+	Try {		
 		$buf = New-Object byte[] 8192
 		$ssh_client_in = [console]::OpenStandardInput()
 		$ssh_client_out = [console]::OpenStandardOutput()
@@ -38,9 +35,20 @@ Function MainLoop {
 		$buf[0] = 0xff
 		$ssh_client_out.Write($buf, 0, 1)
 	
-		while($true) {	
-			$len = RelayMessage $ssh_client_in $ssh_agent $buf "->"
-			$len = RelayMessage $ssh_agent $ssh_client_out $buf "<-"
+		while($true) {
+			Try{
+				$null = $ssh_client_in.Read((New-Object byte[] 1), 0, 0)
+				$ssh_agent = New-Object System.IO.Pipes.NamedPipeClientStream ".", "openssh-ssh-agent", InOut
+				$ssh_agent.Connect()
+				Log "[W] named pipe: connected"
+				$len = RelayMessage $ssh_client_in $ssh_agent $buf "->"
+				$len = RelayMessage $ssh_agent $ssh_client_out $buf "<-"
+			}Finally{
+				If($null -ne $ssh_agent){
+					$ssh_agent.Dispose()
+					Log "[W] named pipe: disconnected"
+				}
+			}
 		}	
 	}
 	Finally {


### PR DESCRIPTION
Thanks for this awesome project! This really saved my day!

I was looking for a simple way to share ssh-agents on WSL2 for a while now. Works perfectly for the ssh-agent shipped with Windows.

Some minor issues occurred when using the application with KeeAgent (https://github.com/dlech/KeeAgent, for getting ssh keys from KeePass) and/or the gpg-agent (for getting ssh keys from hardware tokens e.g. Nitrokey3). Both ssh-agent implementations seem not to like that the named pipe is kept open and will not allow connections from other ssh-clients (e.g. ssh on Windows) while wsl2-ssh-agent is running in WSL.

I had two different ideas of solving this: 
* spawn the PowerShell process only when an ssh-client sends a request or
* make the PowerShell script close the named pipe after reading

My proposal is doing the latter to save the overhead of spawning the PowerShell process on every request. It is a bit of a hack in waiting for a 0 byte read to open the named pipe. I hope you still find this change acceptable.